### PR TITLE
Add overall cluster metrics to dashboard

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
-  constraints = ">= 2.0.0, < 5.0.0"
+  constraints = ">= 3.0.0, < 6.0.0"
   hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
     "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,50 @@ data "aws_region" "current" {}
 locals {
   aws_region = data.aws_region.current.name
 
-  widgets = [for service_name in var.service_names : {
+  cluster_widget = {
+    type   = "metric"
+    width  = 18
+    height = 6
+    properties = {
+      view    = "timeSeries"
+      stacked = false
+      metrics = [
+        ["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name, { color = "#d62728" }],
+        [".", "CPUReservation", ".", ".", { color = "#ff7f0e" }],
+        [".", "MemoryUtilization", ".", ".", { yAxis = "right", color = "#1f77b4" }],
+        [".", "MemoryReservation", ".", ".", { yAxis = "right", color = "#17becf" }]
+      ]
+      stat   = "Maximum"
+      region = local.aws_region,
+      annotations = {
+        horizontal = [
+          {
+            color = "#ff9896"
+            label = "100% CPU"
+            value = 100
+          },
+          {
+            color = "#9edae5"
+            label = "100% Memory"
+            value = 100
+            yAxis = "right"
+          }
+        ]
+      }
+      yAxis = {
+        left = {
+          min = 0
+        }
+        right = {
+          min = 0
+        }
+      }
+      title  = "${var.cluster_name} (cluster)"
+      period = 300
+    }
+  }
+
+  service_widgets = [for service_name in var.service_names : {
     type   = "metric"
     width  = 18
     height = 6
@@ -49,4 +92,6 @@ locals {
       period = 300
     }
   }]
+
+  widgets = concat([local.cluster_widget], local.service_widgets)
 }


### PR DESCRIPTION
### Added
- Add widget for cluster-level metrics (in addition to service-level)

### Fixed
- Update Terraform lock file (automatic, to match versions.tf)